### PR TITLE
Reject filesChanPromise when we disconnect and won't reconnect

### DIFF
--- a/src/fs.ts
+++ b/src/fs.ts
@@ -24,16 +24,26 @@ export class FS implements vscode.FileSystemProvider {
 
   constructor(client: Client<vscode.ExtensionContext>) {
     let resolveFilesChan: (filesChan: Channel) => void;
-    this.filesChanPromise = new Promise((r) => (resolveFilesChan = r));
+    let reject: (e: vscode.FileSystemError) => void;
+    this.filesChanPromise = new Promise((res, rej) => {
+      resolveFilesChan = res;
+      reject = rej;
+    });
     // TODO gcsfiles
-    client.openChannel({ service: "files" }, ({ channel }) => {
-      if (!channel) {
+    client.openChannel({ service: 'files' }, (result) => {
+      if (result.error) {
+        reject(vscode.FileSystemError.Unavailable());
+
         return;
       }
 
-      resolveFilesChan(channel);
+      resolveFilesChan(result.channel);
 
-      return () => {
+      return ({ willReconnect }) => {
+        if (!willReconnect) {
+          reject(vscode.FileSystemError.Unavailable());
+        }
+
         this.filesChanPromise = new Promise((r) => (resolveFilesChan = r));
       };
     });


### PR DESCRIPTION
Reject `filesChanPromise` with `Unavailable` when we disconnect and won't reconnect. This will reject all requests that are waiting for the channel to open.

Though the client can still reconnect in the future and we could be supplied with a new channel eventually (i.e. if `client.open` is called again), it doesn't make sense to keep around pending requests. The client closing without reconnection usually means `client.close` is called. I think we'll be calling that when we need to change repls, in which case all pending requests are not relevant anymore.