### PR TITLE
Allow @username/slug  only like the placeholder promises

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -58,7 +58,7 @@ export async function parseRepl(repl: string): Promise<string | null> {
   if (isReplId(repl)) return repl;
 
   // Check if user included full URL using a simple regex
-  const urlRegex = /http(?:s?):\/\/repl\.it\/@(.+)\/([^?\s#]+)/g;
+  const urlRegex = /(?:http(?:s?):\/\/repl\.it\/)?@(.+)\/([^?\s#]+)/g;
   const match = urlRegex.exec(repl);
   if (!match) {
     return null;


### PR DESCRIPTION
The placeholder says paste `@username/slug` but it doesn't work. This change makes the `https://repl.it/` part optional when pasting a repl.

Allowed input samples:
- `Replid` (a uuid v4)
- `https://repl.it/@username/slug`
- `http://repl.it/@username/slug`
- `@username/slug`

