### PR TITLE
Implement retries on channel closed

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,8 @@ module.exports = {
     'import/no-unresolved': 'off',
     indent: 'off',
     'function-paren-newline': 'off',
+    'space-before-function-paren': 'off',
+    '@typescript-eslint/space-before-function-paren': ['error'],
     'no-restricted-syntax': ['error', 'LabeledStatement', 'WithStatement'],
     'no-await-in-loop': 'off',
     'implicit-arrow-linebreak': 'off', // conflicts with prettier


### PR DESCRIPTION
When the channel closes (meaning the client disconnected as we never explicitly close the channel), we will retry the requests after we have a new filesChanPromise. See comments.