### PR TITLE
Emit on file changes and ignore eslint warns

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,5 +35,6 @@ module.exports = {
     'no-param-reassign': ['error', { props: false }],
     'object-curly-newline': 'off',
     'consistent-return': 'off',
+    'no-console': 'off',
   },
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -200,6 +200,7 @@ const initialize = async (store: Options, ctx: vscode.ExtensionContext) => {
   client.open(
     {
       context: ctx,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       fetchToken: async (abortSignal: any) => {
         let token;
         try {
@@ -229,7 +230,7 @@ const initialize = async (store: Options, ctx: vscode.ExtensionContext) => {
   );
 };
 
-export async function activate(context: vscode.ExtensionContext) {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
   console.log('Extension activating...');
   const store = await Options.create();
   console.log('Initializing...');

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,5 +1,6 @@
 import { Channel, Client } from '@replit/crosis';
 import { api } from '@replit/protocol';
+import { posix as posixPath } from 'path';
 import * as vscode from 'vscode';
 
 function uriToApiPath(uri: vscode.Uri): string {
@@ -14,6 +15,10 @@ function apiToVscodeFileType(type: api.File.Type): vscode.FileType {
 
   // Our API doesn't support symlinks and other types
   return vscode.FileType.File;
+}
+
+function getParentURI(uri: vscode.Uri): vscode.Uri {
+  return vscode.Uri.parse(`replit://${posixPath.dirname(uri.path)}`);
 }
 
 function handleError(errStr: string, uri: vscode.Uri): null {
@@ -86,6 +91,7 @@ export class FS implements vscode.FileSystemProvider {
   // What is this for?
   // async copy() {}
 
+  // eslint-disable-next-line class-methods-use-this
   watch(uri: vscode.Uri): vscode.Disposable {
     console.log('watch', uri.path);
     // What is this for?
@@ -107,8 +113,10 @@ export class FS implements vscode.FileSystemProvider {
 
     handleError(res.error, uri);
 
-    // emit vscode.FileChangeType.Created
-    // emit vscode.FileChangeType.Changed on parent
+    this.emitter.fire([
+      { type: vscode.FileChangeType.Created, uri },
+      { type: vscode.FileChangeType.Changed, uri: getParentURI(uri) },
+    ]);
   }
 
   async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
@@ -154,6 +162,7 @@ export class FS implements vscode.FileSystemProvider {
     return res.file.content;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async delete(uri: vscode.Uri, _options: { recursive: boolean }): Promise<void> {
     // Ignoring recursive option for now. I'm not sure when vscode would
     // ask us to delete a directory non-recursively, and what is the correct
@@ -170,9 +179,10 @@ export class FS implements vscode.FileSystemProvider {
 
     handleError(res.error, uri);
 
-    // TODO
-    // emit vscode.FileChangeType.Changed for parent directory
-    // emit vscode.FileChangeType.Deleted
+    this.emitter.fire([
+      { type: vscode.FileChangeType.Deleted, uri },
+      { type: vscode.FileChangeType.Changed, uri: getParentURI(uri) },
+    ]);
   }
 
   async rename(
@@ -223,6 +233,12 @@ export class FS implements vscode.FileSystemProvider {
     // vscode.FileChangeType.Deleted oldUri
     // vscode.FileChangeType.Created newUri
     // vscode.FileChangeType.Changed newUri and oldUri parents
+    this.emitter.fire([
+      { type: vscode.FileChangeType.Deleted, uri: oldUri },
+      { type: vscode.FileChangeType.Created, uri: newUri },
+      { type: vscode.FileChangeType.Changed, uri: getParentURI(oldUri) },
+      { type: vscode.FileChangeType.Changed, uri: getParentURI(newUri) },
+    ]);
   }
 
   async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
@@ -300,9 +316,15 @@ export class FS implements vscode.FileSystemProvider {
 
     handleError(res.error, uri);
 
-    // TODO
-    // if options.create emit vscode.FileChangeType.Created
-    // if options.create emit vscode.FileChangeType.Changed on parent
-    // emit vscode.FileChangeType.Changed
+    // Might as well do them all in one emit
+    const evts: vscode.FileChangeEvent[] = [];
+
+    if (options.create) {
+      evts.push({ type: vscode.FileChangeType.Created, uri });
+      evts.push({ type: vscode.FileChangeType.Changed, uri: getParentURI(uri) });
+    }
+    evts.push({ type: vscode.FileChangeType.Changed, uri });
+
+    this.emitter.fire(evts);
   }
 }


### PR DESCRIPTION
Resolves todos on emitting on file changes and removes eslint warnings. Disabled no-console for now and we can re-enable that if we want to remove logs at some point.