### PR TITLE
Allow multiple repls to be opened at once

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -508,8 +508,7 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"axe-core": {
 			"version": "4.1.1",
@@ -729,7 +728,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -767,6 +765,14 @@
 			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.8.2.tgz",
 			"integrity": "sha512-v6zfIQqL/pzTVAbZvYUozsxNfxcFb6Ks3ZfEbuneJl3FW9Jb8F6vLWB6f+qTmAu72msUdyb84V8d/yBFf7FNnw==",
 			"dev": true
+		},
+		"cross-fetch": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+			"integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+			"requires": {
+				"node-fetch": "2.6.1"
+			}
 		},
 		"cross-spawn": {
 			"version": "7.0.3",
@@ -818,8 +824,7 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"diff": {
 			"version": "4.0.2",
@@ -1338,6 +1343,11 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
+		"extract-files": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+			"integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ=="
+		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1439,7 +1449,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
 			"integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
@@ -1539,6 +1548,21 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
 			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
 			"dev": true
+		},
+		"graphql": {
+			"version": "15.4.0",
+			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
+			"integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA=="
+		},
+		"graphql-request": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.4.0.tgz",
+			"integrity": "sha512-acrTzidSlwAj8wBNO7Q/UQHS8T+z5qRGquCQRv9J1InwR01BBWV9ObnoE+JS5nCCEj8wSGS0yrDXVDoRiKZuOg==",
+			"requires": {
+				"cross-fetch": "^3.0.6",
+				"extract-files": "^9.0.0",
+				"form-data": "^3.0.0"
+			}
 		},
 		"growl": {
 			"version": "1.10.5",
@@ -1975,14 +1999,12 @@
 		"mime-db": {
 			"version": "1.45.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-			"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
-			"dev": true
+			"integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
 		},
 		"mime-types": {
 			"version": "2.1.28",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
 			"integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
-			"dev": true,
 			"requires": {
 				"mime-db": "1.45.0"
 			}

--- a/package.json
+++ b/package.json
@@ -18,12 +18,17 @@
     "commands": [
       {
         "command": "replit.openrepl",
-        "title": "Select a repl",
+        "title": "Open a repl",
         "category": "Replit"
       },
       {
         "command": "replit.shell",
-        "title": "shell",
+        "title": "Open a shell for a repl",
+        "category": "Replit"
+      },
+      {
+        "command": "replit.apikey",
+        "title": "Add or change API key",
         "category": "Replit"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -20,6 +20,11 @@
         "command": "replit.init",
         "title": "init",
         "category": "Replit"
+      },
+      {
+        "command": "replit.shell",
+        "title": "shell",
+        "category": "Replit"
       }
     ],
     "menus": {
@@ -27,6 +32,10 @@
         {
           "command": "replit.init",
           "when": "workbenchState != workspace"
+        },
+        {
+          "command": "replit.shell",
+          "when": "workbenchState == workspace"
         }
       ]
     }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
   "dependencies": {
     "@replit/crosis": "^6.0.4",
     "@replit/protocol": "^0.2.16",
+    "graphql": "^15.4.0",
+    "graphql-request": "^3.4.0",
     "node-fetch": "^2.6.1",
     "ws": "^7.4.2"
   }

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
   ],
   "activationEvents": [
     "onFileSystem:replit",
-    "onCommand:replit.init"
+    "onCommand:replit.openrepl"
   ],
   "main": "./dist/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "replit.init",
-        "title": "init",
+        "command": "replit.openrepl",
+        "title": "Select a repl",
         "category": "Replit"
       },
       {
@@ -29,10 +29,6 @@
     ],
     "menus": {
       "commandPalette": [
-        {
-          "command": "replit.init",
-          "when": "workbenchState != workspace"
-        },
         {
           "command": "replit.shell",
           "when": "workbenchState == workspace"

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,116 @@
+import fetch from 'node-fetch';
+import { AbortSignal } from 'node-fetch/externals';
+import { GraphQLClient, gql } from 'graphql-request';
+import { ReplInfo } from './types';
+
+const gqlClient = new GraphQLClient('https://repl.it/graphql/', {});
+gqlClient.setHeaders({
+  'X-Requested-With': 'graph',
+  'user-agent': 'lol',
+  referrer: 'https://repl.it',
+});
+
+const ReplInfoFromUrlDoc = gql`
+  query ReplInfoFromUrl($url: String!) {
+    repl(url: $url) {
+      ... on Repl {
+        id
+        user {
+          username
+        }
+        slug
+      }
+    }
+  }
+`;
+
+const ReplInfoFromIdDoc = gql`
+  query ReplInfoFromUrl($id: String!) {
+    repl(id: $id) {
+      ... on Repl {
+        id
+        user {
+          username
+        }
+        slug
+      }
+    }
+  }
+`;
+
+async function getReplInfoByUrl(url: string): Promise<ReplInfo> {
+  const result = await gqlClient.request(ReplInfoFromUrlDoc, { url });
+
+  if (!result.repl) {
+    throw new Error('unexpected grqphql response for url');
+  }
+
+  return {
+    id: result.repl.id,
+    user: result.repl.user.username,
+    slug: result.repl.slug,
+  };
+}
+
+async function getReplInfoById(id: string): Promise<ReplInfo> {
+  const result = await gqlClient.request(ReplInfoFromIdDoc, { id });
+
+  if (!result.repl) {
+    throw new Error('unexpected grqphql response for url');
+  }
+
+  return {
+    id: result.repl.id,
+    user: result.repl.user.username,
+    slug: result.repl.slug,
+  };
+}
+
+export async function getReplInfo(input: string): Promise<ReplInfo> {
+  if (input.split('-').length === 5) {
+    return getReplInfoById(input);
+  }
+
+  // Check if user included full URL using a simple regex
+  const urlRegex = /(?:http(?:s?):\/\/repl\.it\/)?@(.+)\/([^?\s#]+)/g;
+  const match = urlRegex.exec(input);
+  if (!match) {
+    throw new Error('Please input in the format of @username/replname or full url of the repl');
+  }
+
+  const [, user, slug] = match;
+
+  return getReplInfoByUrl(`https://repl.it/@${user}/${slug}`);
+}
+
+export async function fetchToken(
+  abortSignal: AbortSignal,
+  replId: string,
+  apiKey: string,
+): Promise<string> {
+  const r = await fetch(`https://repl.it/api/v0/repls/${replId}/token`, {
+    signal: abortSignal,
+    method: 'POST',
+    headers: {
+      accept: 'application/json',
+      'content-Type': 'application/json',
+      'user-agent': 'ezcrosis',
+      'x-requested-with': 'ezcrosis',
+    },
+    body: JSON.stringify({ apiKey }),
+  });
+  const text = await r.text();
+
+  let res;
+  try {
+    res = JSON.parse(text);
+  } catch (e) {
+    throw new Error(`Invalid JSON while fetching token for ${replId}: ${JSON.stringify(text)}`);
+  }
+
+  if (typeof res !== 'string') {
+    throw new Error(`Invalid token response: ${JSON.stringify(res)}`);
+  }
+
+  return res;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -162,6 +162,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
 
   context.subscriptions.push(
+    vscode.workspace.onDidChangeWorkspaceFolders((ev) => {
+      ev.removed.forEach((folder) => {
+        const maybeReplId = folder.uri.authority;
+
+        if (openedRepls[maybeReplId]) {
+          openedRepls[maybeReplId].client.destroy();
+          delete openedRepls[maybeReplId];
+        }
+      });
+    }),
+  );
+
+  context.subscriptions.push(
     vscode.commands.registerCommand('replit.shell', async () => {
       if (Object.values(openedRepls).length === 0) {
         return vscode.window.showErrorMessage('Please open a repl first');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -280,10 +280,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         },
       );
 
-      console.log(vscode.Uri.parse(`replit:/${replInfo.id}`));
+      console.log(vscode.Uri.parse(`replit:/${replInfo.id}/`));
 
       vscode.workspace.updateWorkspaceFolders(0, 0, {
-        uri: vscode.Uri.parse(`replit:/${replInfo.id}`),
+        uri: vscode.Uri.parse(`replit:/${replInfo.id}/`),
         name: `@${replInfo.user}/${replInfo.slug}`,
       });
     }),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -280,7 +280,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         },
       );
 
-      console.log(vscode.Uri.parse(`replit:/${replInfo.id}`))
+      console.log(vscode.Uri.parse(`replit:/${replInfo.id}`));
 
       vscode.workspace.updateWorkspaceFolders(0, 0, {
         uri: vscode.Uri.parse(`replit:/${replInfo.id}`),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,12 @@
 /* eslint-disable max-classes-per-file */
 import { Client } from '@replit/crosis';
-import { api } from '@replit/protocol';
 import fetch, { Response } from 'node-fetch';
 import { AbortSignal } from 'node-fetch/externals';
 import * as vscode from 'vscode';
 import ws from 'ws';
 import { FS } from './fs';
 import { Options } from './options';
-import ReplitTerminal from './shell';
+// import ReplitTerminal from './shell';
 
 const BAD_KEY_MSG = 'Please enter a valid crosis key';
 
@@ -236,6 +235,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         client,
       };
 
+      fs.addRepl(replInfo.id, client);
+
       client.open(
         {
           context: {
@@ -279,9 +280,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         },
       );
 
+      console.log(vscode.Uri.parse(`replit:/${replInfo.id}`))
+
       vscode.workspace.updateWorkspaceFolders(0, 0, {
-        uri: vscode.Uri.parse(`replit://${replInfo.id}`),
-        name: '@masfrost/vscode-demo',
+        uri: vscode.Uri.parse(`replit:/${replInfo.id}`),
+        name: `@${replInfo.user}/${replInfo.slug}`,
       });
     }),
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import * as vscode from 'vscode';
 import ws from 'ws';
 import { FS } from './fs';
 import { Options } from './options';
+import ReplitTerminal from './shell';
 
 const BAD_KEY_MSG = 'Please enter a valid crosis key';
 
@@ -205,6 +206,15 @@ const initialize = async (store: Options, ctx: vscode.ExtensionContext) => {
     }),
   );
 
+  ctx.subscriptions.push(
+    vscode.commands.registerCommand('replit.shell', () => {
+      vscode.window.createTerminal({
+        name: 'repl',
+        pty: new ReplitTerminal(client),
+      });
+    }),
+  );
+
   client.open(
     {
       context: ctx,
@@ -251,7 +261,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('replit.init', () =>
       vscode.workspace.updateWorkspaceFolders(0, 0, {
         uri: vscode.Uri.parse('replit:/'),
-        name: 'Repl.it',
+        name: '@masfrost/python3',
       }),
     ),
   );

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -66,7 +66,7 @@ export class FS implements vscode.FileSystemProvider {
     this.replFsMap = {};
   }
 
-  addRepl(replId: string, client: Client<vscode.ExtensionContext>) {
+  addRepl(replId: string, client: Client<any>) {
     const replFs = new ReplFs(client, this.emitter);
     this.replFsMap[replId] = replFs;
   }
@@ -95,7 +95,9 @@ export class FS implements vscode.FileSystemProvider {
   async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
     const replId = replIdFromUri(uri);
 
+
     const fs = this.replFsMap[replId];
+    console.log('reading ', uri.path, replId, !!fs)
 
     if (!fs) {
       throw new Error('Expected fs in replFsMap');
@@ -181,7 +183,7 @@ class ReplFs implements vscode.FileSystemProvider {
   onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]>;
 
   constructor(
-    client: Client<vscode.ExtensionContext>,
+    client: Client<any>,
     emitter: vscode.EventEmitter<vscode.FileChangeEvent[]>,
   ) {
     let resolveFilesChan: (filesChan: Channel) => void;

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,4 +1,5 @@
 /* eslint-disable class-methods-use-this */
+// eslint-disable-next-line max-classes-per-file
 import { Channel, Client } from '@replit/crosis';
 import { api } from '@replit/protocol';
 import { posix as posixPath } from 'path';
@@ -51,130 +52,6 @@ function handleError(errStr: string, uri: vscode.Uri): null {
   throw new Error(errStr);
 }
 
-export class FS implements vscode.FileSystemProvider {
-  private emitter: vscode.EventEmitter<vscode.FileChangeEvent[]>;
-
-  onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]>;
-
-  replFsMap: {
-    [replId: string]: ReplFs;
-  };
-
-  constructor() {
-    this.emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
-    this.onDidChangeFile = this.emitter.event;
-    this.replFsMap = {};
-  }
-
-  addRepl(replId: string, client: Client<any>) {
-    const replFs = new ReplFs(client, this.emitter);
-    this.replFsMap[replId] = replFs;
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  watch(uri: vscode.Uri): vscode.Disposable {
-    console.log('watch', uri.path);
-    // What is this for?
-    return {
-      dispose: () => {},
-    };
-  }
-
-  async createDirectory(uri: vscode.Uri): Promise<void> {
-    const replId = replIdFromUri(uri);
-
-    const fs = this.replFsMap[replId];
-
-    if (!fs) {
-      throw new Error('Expected fs in replFsMap');
-    }
-
-    return fs.createDirectory(uri);
-  }
-
-  async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
-    const replId = replIdFromUri(uri);
-
-
-    const fs = this.replFsMap[replId];
-    console.log('reading ', uri.path, replId, !!fs)
-
-    if (!fs) {
-      throw new Error('Expected fs in replFsMap');
-    }
-
-    return fs.readDirectory(uri);
-  }
-
-  async writeFile(
-    uri: vscode.Uri,
-    content: Uint8Array,
-    options: { create: boolean; overwrite: boolean },
-  ): Promise<void> {
-    const replId = replIdFromUri(uri);
-
-    const fs = this.replFsMap[replId];
-
-    if (!fs) {
-      throw new Error('Expected fs in replFsMap');
-    }
-
-    return fs.writeFile(uri, content, options);
-  }
-
-  async readFile(uri: vscode.Uri): Promise<Uint8Array> {
-    const replId = replIdFromUri(uri);
-
-    const fs = this.replFsMap[replId];
-
-    if (!fs) {
-      throw new Error('Expected fs in replFsMap');
-    }
-
-    return fs.readFile(uri);
-  }
-
-  async delete(uri: vscode.Uri, options: { recursive: boolean }): Promise<void> {
-    const replId = replIdFromUri(uri);
-
-    const fs = this.replFsMap[replId];
-
-    if (!fs) {
-      throw new Error('Expected fs in replFsMap');
-    }
-
-    return fs.delete(uri, options);
-  }
-
-  async rename(
-    oldUri: vscode.Uri,
-    newUri: vscode.Uri,
-    options: { overwrite: boolean },
-  ): Promise<void> {
-    const replId = replIdFromUri(oldUri);
-
-    const fs = this.replFsMap[replId];
-
-    if (!fs) {
-      throw new Error('Expected fs in replFsMap');
-    }
-
-    return fs.rename(oldUri, newUri, options);
-  }
-
-  async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
-    const replId = replIdFromUri(uri);
-
-    const fs = this.replFsMap[replId];
-
-    if (!fs) {
-      throw new Error('Expected fs in replFsMap');
-    }
-
-    return fs.stat(uri);
-  }
-}
-
 class ReplFs implements vscode.FileSystemProvider {
   private filesChanPromise: Promise<Channel>;
 
@@ -182,10 +59,7 @@ class ReplFs implements vscode.FileSystemProvider {
 
   onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]>;
 
-  constructor(
-    client: Client<any>,
-    emitter: vscode.EventEmitter<vscode.FileChangeEvent[]>,
-  ) {
+  constructor(client: Client<any>, emitter: vscode.EventEmitter<vscode.FileChangeEvent[]>) {
     let resolveFilesChan: (filesChan: Channel) => void;
     let reject: (e: vscode.FileSystemError) => void;
     this.filesChanPromise = new Promise((res, rej) => {
@@ -487,5 +361,128 @@ class ReplFs implements vscode.FileSystemProvider {
     evts.push({ type: vscode.FileChangeType.Changed, uri });
 
     this.emitter.fire(evts);
+  }
+}
+
+export class FS implements vscode.FileSystemProvider {
+  private emitter: vscode.EventEmitter<vscode.FileChangeEvent[]>;
+
+  onDidChangeFile: vscode.Event<vscode.FileChangeEvent[]>;
+
+  replFsMap: {
+    [replId: string]: ReplFs;
+  };
+
+  constructor() {
+    this.emitter = new vscode.EventEmitter<vscode.FileChangeEvent[]>();
+    this.onDidChangeFile = this.emitter.event;
+    this.replFsMap = {};
+  }
+
+  addRepl(replId: string, client: Client<any>) {
+    const replFs = new ReplFs(client, this.emitter);
+    this.replFsMap[replId] = replFs;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  watch(uri: vscode.Uri): vscode.Disposable {
+    console.log('watch', uri.path);
+    // What is this for?
+    return {
+      dispose: () => {},
+    };
+  }
+
+  async createDirectory(uri: vscode.Uri): Promise<void> {
+    const replId = replIdFromUri(uri);
+
+    const fs = this.replFsMap[replId];
+
+    if (!fs) {
+      throw new Error('Expected fs in replFsMap');
+    }
+
+    return fs.createDirectory(uri);
+  }
+
+  async readDirectory(uri: vscode.Uri): Promise<[string, vscode.FileType][]> {
+    const replId = replIdFromUri(uri);
+
+    const fs = this.replFsMap[replId];
+    console.log('reading ', uri.path, replId, !!fs);
+
+    if (!fs) {
+      throw new Error('Expected fs in replFsMap');
+    }
+
+    return fs.readDirectory(uri);
+  }
+
+  async writeFile(
+    uri: vscode.Uri,
+    content: Uint8Array,
+    options: { create: boolean; overwrite: boolean },
+  ): Promise<void> {
+    const replId = replIdFromUri(uri);
+
+    const fs = this.replFsMap[replId];
+
+    if (!fs) {
+      throw new Error('Expected fs in replFsMap');
+    }
+
+    return fs.writeFile(uri, content, options);
+  }
+
+  async readFile(uri: vscode.Uri): Promise<Uint8Array> {
+    const replId = replIdFromUri(uri);
+
+    const fs = this.replFsMap[replId];
+
+    if (!fs) {
+      throw new Error('Expected fs in replFsMap');
+    }
+
+    return fs.readFile(uri);
+  }
+
+  async delete(uri: vscode.Uri, options: { recursive: boolean }): Promise<void> {
+    const replId = replIdFromUri(uri);
+
+    const fs = this.replFsMap[replId];
+
+    if (!fs) {
+      throw new Error('Expected fs in replFsMap');
+    }
+
+    return fs.delete(uri, options);
+  }
+
+  async rename(
+    oldUri: vscode.Uri,
+    newUri: vscode.Uri,
+    options: { overwrite: boolean },
+  ): Promise<void> {
+    const replId = replIdFromUri(oldUri);
+
+    const fs = this.replFsMap[replId];
+
+    if (!fs) {
+      throw new Error('Expected fs in replFsMap');
+    }
+
+    return fs.rename(oldUri, newUri, options);
+  }
+
+  async stat(uri: vscode.Uri): Promise<vscode.FileStat> {
+    const replId = replIdFromUri(uri);
+
+    const fs = this.replFsMap[replId];
+
+    if (!fs) {
+      throw new Error('Expected fs in replFsMap');
+    }
+
+    return fs.stat(uri);
   }
 }

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -6,11 +6,14 @@ import { posix as posixPath } from 'path';
 import * as vscode from 'vscode';
 
 function replIdFromUri({ path }: vscode.Uri): string {
-  return path.split('/')[0];
+  return path.split('/')[1];
 }
 
 function uriToApiPath({ path }: vscode.Uri): string {
   const pathWithoutReplId = path.split('/').slice(1).join('/');
+
+  console.log(`.${pathWithoutReplId}`);
+
   return `.${pathWithoutReplId}`;
 }
 
@@ -123,8 +126,6 @@ class ReplFs implements vscode.FileSystemProvider {
 
   // eslint-disable-next-line class-methods-use-this
   watch(uri: vscode.Uri): vscode.Disposable {
-    console.log('watch', uri.path);
-    // What is this for?
     return {
       dispose: () => {},
     };
@@ -386,8 +387,6 @@ export class FS implements vscode.FileSystemProvider {
 
   // eslint-disable-next-line class-methods-use-this
   watch(uri: vscode.Uri): vscode.Disposable {
-    console.log('watch', uri.path);
-    // What is this for?
     return {
       dispose: () => {},
     };
@@ -478,6 +477,7 @@ export class FS implements vscode.FileSystemProvider {
     const replId = replIdFromUri(uri);
 
     const fs = this.replFsMap[replId];
+    console.log('stating ', uri.path, replId, !!fs);
 
     if (!fs) {
       throw new Error('Expected fs in replFsMap');

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode';
+import { Channel, Client } from '@replit/crosis';
+
+export default class ReplitTerminal implements vscode.Pseudoterminal {
+  private client: Client<vscode.ExtensionContext>;
+  private channel: Channel | null;
+  private dimensions: vscode.TerminalDimensions | undefined;
+  private emitter: vscode.EventEmitter<string>;
+  onDidWrite: vscode.Event<string>;
+
+  constructor(client: Client<vscode.ExtensionContext>) {
+    this.dimensions = undefined;
+    this.channel = null;
+    this.client = client;
+
+    this.emitter = new vscode.EventEmitter<string>();
+    this.onDidWrite = this.emitter.event;
+  }
+
+  close() {}
+
+  handleInput(input: string) {
+    console.log('input', input, !!this.channel);
+    if (!this.channel) {
+      return;
+    }
+
+    this.channel.send({ input });
+  }
+
+  open(dimensions: vscode.TerminalDimensions | undefined) {
+    console.log('open');
+    this.dimensions = dimensions;
+
+    this.client.openChannel({ service: 'shell' }, (result) => {
+      if (!result.channel) {
+        return;
+      }
+
+      this.channel = result.channel;
+
+      result.channel.onCommand((cmd) => {
+        console.log(cmd.output);
+        if (!cmd.output) {
+          return;
+        }
+
+        this.emitter.fire(cmd.output);
+      });
+
+      if (this.dimensions) {
+        result.channel.send({
+          resizeTerm: {
+            cols: this.dimensions.columns,
+            rows: this.dimensions.rows,
+          },
+        });
+      }
+    });
+  }
+
+  setDimensions(dimensions: vscode.TerminalDimensions) {
+    this.dimensions = dimensions;
+
+    if (!this.channel) {
+      return;
+    }
+
+    this.channel.send({
+      resizeTerm: {
+        cols: dimensions.columns,
+        rows: dimensions.rows,
+      },
+    });
+  }
+}

--- a/src/shell.ts
+++ b/src/shell.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
-import { Channel, Client } from '@replit/crosis';
+import { Channel } from '@replit/crosis';
+import { CrosisClient } from './types';
 
 export default class ReplitTerminal implements vscode.Pseudoterminal {
-  private client: Client<vscode.ExtensionContext>;
+  private client: CrosisClient;
 
   private channel: Channel | null;
 
@@ -14,7 +15,7 @@ export default class ReplitTerminal implements vscode.Pseudoterminal {
 
   onDidWrite: vscode.Event<string>;
 
-  constructor(client: Client<any>) {
+  constructor(client: CrosisClient) {
     this.dimensions = undefined;
     this.channel = null;
     this.closeChannel = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,13 @@
+import { Client } from '@replit/crosis';
+import * as vscode from 'vscode';
+
+export interface ReplInfo {
+  id: string;
+  user: string;
+  slug: string;
+}
+
+export type CrosisClient = Client<{
+  extensionContext: vscode.ExtensionContext;
+  replInfo: ReplInfo;
+}>;


### PR DESCRIPTION
Required a major refactor for this to work.

- The FS provider now a multiplexer to a per repl provider, it uses the replId (uri authority of the workspace folder) to forward the requests
- Support opening any `replit:/` uri regardless of whether we opened the repl through the command pallet or not (supports saved workspace configs)
- Multiple shells are now allowed. Shells can only be opened for opened repls
- Use graphql API to get repl information
- Moved some functions around
